### PR TITLE
Make check-links work under OSX

### DIFF
--- a/check-links
+++ b/check-links
@@ -12,8 +12,7 @@ fi
 WEBSITE="$1"
 DIR="$(mktemp -d /tmp/check-links-XXXXXXXXXX)"
 LOG="${DIR}/wget.log"
-REGEX='HTTP request sent, awaiting response... (?!200)'
-readonly WEBSITE DIR LOG REGEX
+readonly WEBSITE DIR LOG
 
 cd "${DIR}"
 wget \
@@ -23,5 +22,5 @@ wget \
   --recursive \
   --page-requisites \
   "${WEBSITE}" || true
-grep -B 2 --perl-regex "${REGEX}" "${LOG}" || true
+perl -ne 'print $b[0],$_ if /HTTP request sent, awaiting response... (?!200)/; push @b, $_; shift @b if @b > 2' "${LOG}" || true
 echo "See ${LOG} and the contents of ${DIR} for further investigation"


### PR DESCRIPTION
...and under every other system that doesn't have gnu grep. Also, perl. Yay! :)
